### PR TITLE
seperating ambiguous alternatives with commas in CSV no longer works …

### DIFF
--- a/CLMS-CSV.php
+++ b/CLMS-CSV.php
@@ -173,7 +173,7 @@
          <div class="container">
             <h4>Ambiguous Linkage Sites</h4>
             <p>Ambiguous links are represented by listing the
-            alternative linkage sites separated by commas or
+            alternative linkage sites separated by 
             semi-colons in the protein and position fields. For
             example:</p>
             <table class="hor-minimalist-a" style=


### PR DESCRIPTION
…because db is stripping out quotation marks. Updated doc for csv file format.